### PR TITLE
Enable tag and type filters in search

### DIFF
--- a/apps/web/app/api/bookmarks/route.ts
+++ b/apps/web/app/api/bookmarks/route.ts
@@ -4,6 +4,7 @@ import {
 } from "@/lib/database/create-bookmark";
 import { userRoute } from "@/lib/safe-route";
 import { advancedSearch } from "@/lib/search/advanced-search";
+import { BookmarkType } from "@workspace/database";
 import { NextResponse } from "next/server";
 import { z } from "zod";
 
@@ -30,6 +31,7 @@ export const GET = userRoute
     z.object({
       query: z.string().optional(),
       tags: z.array(z.string()).optional(),
+      types: z.array(z.nativeEnum(BookmarkType)).optional(),
       cursor: z.string().optional(),
       limit: z.coerce.number().min(1).max(50).optional(),
       matchingDistance: z.coerce.number().min(0.1).max(2).optional(),
@@ -40,6 +42,7 @@ export const GET = userRoute
       userId: ctx.user.id,
       query: query.query,
       tags: query.tags || [],
+      types: query.types || [],
       limit: query.limit || 20,
       cursor: query.cursor,
       matchingDistance: query.matchingDistance || 0.1,

--- a/apps/web/app/app/search-input.tsx
+++ b/apps/web/app/app/search-input.tsx
@@ -1,9 +1,23 @@
 import { Button } from "@workspace/ui/components/button";
 import { Input } from "@workspace/ui/components/input";
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandItem,
+  CommandList,
+} from "@workspace/ui/components/command";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@workspace/ui/components/popover";
 import { Plus, Search } from "lucide-react";
 import { useQueryState } from "nuqs";
-import { useRef } from "react";
+import { useEffect, useRef, useState } from "react";
 import { toast } from "sonner";
+import { BookmarkType } from "@workspace/database";
+import { useTags } from "@/features/tags/use-tags";
 import { URL_SCHEMA } from "./schema";
 import { useCreateBookmarkAction } from "./use-create-bookmark";
 
@@ -15,7 +29,30 @@ export const SearchInput = (props: SearchInputProps) => {
   });
   const inputRef = useRef<HTMLInputElement>(null);
 
+  const [mentionOpen, setMentionOpen] = useState(false);
+  const [mentionType, setMentionType] = useState<"tag" | "type" | null>(null);
+  const [mentionQuery, setMentionQuery] = useState("");
+
+  const { data: tags = [] } = useTags();
+
   const isUrl = URL_SCHEMA.safeParse(query).success;
+
+  const handleMentionDetection = (value: string) => {
+    const tagMatch = value.match(/(?:^|\s)#([^#@\s]*)$/);
+    const typeMatch = value.match(/(?:^|\s)@([^#@\s]*)$/);
+
+    if (tagMatch) {
+      setMentionType("tag");
+      setMentionQuery(tagMatch[1]);
+      setMentionOpen(true);
+    } else if (typeMatch) {
+      setMentionType("type");
+      setMentionQuery(typeMatch[1]);
+      setMentionOpen(true);
+    } else {
+      setMentionOpen(false);
+    }
+  };
 
   const action = useCreateBookmarkAction({
     onSuccess: () => {
@@ -28,27 +65,90 @@ export const SearchInput = (props: SearchInputProps) => {
     },
   });
 
+  useEffect(() => {
+    handleMentionDetection(query);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const handleSelect = (value: string) => {
+    if (!mentionType) return;
+    const prefix = mentionType === "tag" ? "#" : "@";
+    const regex = mentionType === "tag"
+      ? /(?:^|\s)#([^#@\s]*)$/
+      : /(?:^|\s)@([^#@\s]*)$/;
+
+    const newQuery = query.replace(regex, (match) => {
+      const start = match.startsWith(" ") ? " " : "";
+      return `${start}${prefix}${value}`;
+    });
+
+    setQuery(newQuery + " ");
+    setMentionOpen(false);
+    inputRef.current?.focus();
+  };
+
   return (
     <div className="flex items-center gap-2">
-      <div className="flex-1 relative">
-        {isUrl ? (
-          <Plus className="absolute left-4 top-1/2 -translate-y-1/2 pointer-events-none" />
-        ) : (
-          <Search className="absolute left-4 top-1/2 -translate-y-1/2 pointer-events-none" />
-        )}
-        <Input
-          ref={inputRef}
-          defaultValue={query}
-          className="lg:h-16 lg:px-6 lg:rounded-xl lg:py-4 lg:text-2xl bg-background pl-8 lg:pl-12"
-          onChange={(e) => setQuery(e.target.value)}
-          placeholder="Search bookmarks"
-          onKeyDown={(e) => {
-            if (e.key === "Enter" && isUrl) {
-              action.execute({ url: query });
-            }
-          }}
-        />
-      </div>
+      <Popover open={mentionOpen} onOpenChange={setMentionOpen}>
+        <PopoverTrigger asChild>
+          <div className="flex-1 relative">
+            {isUrl ? (
+              <Plus className="absolute left-4 top-1/2 -translate-y-1/2 pointer-events-none" />
+            ) : (
+              <Search className="absolute left-4 top-1/2 -translate-y-1/2 pointer-events-none" />
+            )}
+            <Input
+              ref={inputRef}
+              defaultValue={query}
+              className="lg:h-16 lg:px-6 lg:rounded-xl lg:py-4 lg:text-2xl bg-background pl-8 lg:pl-12"
+              onChange={(e) => {
+                setQuery(e.target.value);
+                handleMentionDetection(e.target.value);
+              }}
+              placeholder="Search bookmarks, use #tag or @type"
+              onKeyDown={(e) => {
+                if (e.key === "Enter" && isUrl) {
+                  action.execute({ url: query });
+                }
+              }}
+            />
+          </div>
+        </PopoverTrigger>
+        <PopoverContent className="w-56 p-0" align="start">
+          <Command>
+            <CommandList>
+              {mentionType === "tag" && (
+                <CommandGroup heading="Tags">
+                  {tags
+                    .filter((t) => t.name.toLowerCase().includes(mentionQuery.toLowerCase()))
+                    .map((tag) => (
+                      <CommandItem key={tag.id} onSelect={() => handleSelect(tag.name)}>
+                        {tag.name}
+                      </CommandItem>
+                    ))}
+                  {tags.filter((t) => t.name.toLowerCase().includes(mentionQuery.toLowerCase())).length === 0 && (
+                    <CommandEmpty>No tags found</CommandEmpty>
+                  )}
+                </CommandGroup>
+              )}
+              {mentionType === "type" && (
+                <CommandGroup heading="Types">
+                  {Object.values(BookmarkType)
+                    .filter((t) => t.toLowerCase().includes(mentionQuery.toLowerCase()))
+                    .map((type) => (
+                      <CommandItem key={type} onSelect={() => handleSelect(type)}>
+                        {type}
+                      </CommandItem>
+                    ))}
+                  {Object.values(BookmarkType).filter((t) => t.toLowerCase().includes(mentionQuery.toLowerCase())).length === 0 && (
+                    <CommandEmpty>No types found</CommandEmpty>
+                  )}
+                </CommandGroup>
+              )}
+            </CommandList>
+          </Command>
+        </PopoverContent>
+      </Popover>
       {isUrl ? (
         <Button
           onClick={() => {


### PR DESCRIPTION
## Summary
- support `#tags` and `@BookmarkType` filters in search
- parse typed tags and types when searching
- filter API requests by tag and bookmark type
- update advanced search to handle bookmark type filter
- hint at new syntax in search bar placeholder
- add popover suggestions for tags and types in search input

## Testing
- `pnpm lint` *(fails: Request was cancelled due to missing network access)*

------
https://chatgpt.com/codex/tasks/task_e_685758a277848326bf9a7d9fe09f1f35