### PR TITLE
Fix #22: Add default SaveIt.now bookmark for new users to improve first-visit UX

### DIFF
--- a/apps/web/src/lib/auth.ts
+++ b/apps/web/src/lib/auth.ts
@@ -6,6 +6,7 @@ import { prismaAdapter } from "better-auth/adapters/prisma";
 import { nextCookies } from "better-auth/next-js";
 import { admin, emailOTP, magicLink } from "better-auth/plugins";
 import { AUTH_LIMITS } from "./auth-limits";
+import { createBookmark } from "./database/create-bookmark";
 import { inngest } from "./inngest/client";
 import { resend } from "./resend";
 import { getServerUrl } from "./server-url";
@@ -87,6 +88,17 @@ Melvyn`,
     user: {
       create: {
         after: async (user) => {
+          // Create welcome bookmark for new users
+          try {
+            await createBookmark({
+              url: "https://saveit.now",
+              userId: user.id,
+            });
+          } catch (error) {
+            // Log error but don't fail user creation
+            console.error("Failed to create welcome bookmark for user:", user.id, error);
+          }
+
           inngest.send({
             name: "user/new-subscriber",
             data: {


### PR DESCRIPTION
## Summary
- Adds a default SaveIt.now bookmark for all new users during account creation
- Resolves the mysterious empty cards and confusing first-visit experience described in #22

## Changes Made
- Modified `auth.ts` to create a welcome bookmark pointing to `https://saveit.now` in the user creation hook
- Added error handling to ensure user creation doesn't fail if bookmark creation fails
- Import added for `createBookmark` function from database utilities

## Test Plan
- [x] TypeScript check passes
- [x] Lint check passes
- [ ] Create a new user account and verify default bookmark appears
- [ ] Verify user creation still works if bookmark creation fails
- [ ] Check that new users no longer see empty state on first visit

This improvement ensures new users always have at least one bookmark when they first visit the app, eliminating the confusing empty state experience.

Fixes #22