### PR TITLE
💡 Add tooltip for read button on bookmark cards

### DIFF
--- a/apps/web/app/app/bookmark-card/bookmark-card-actions.tsx
+++ b/apps/web/app/app/bookmark-card/bookmark-card-actions.tsx
@@ -64,7 +64,6 @@ export const BookmarkCardActions = ({
           variant="secondary"
           size="icon"
           className="size-8 hover:bg-accent"
-          showTooltip={false}
         />
       )}
       {children}


### PR DESCRIPTION
## Summary
- Enable tooltip display for read buttons in bookmark cards
- Remove `showTooltip={false}` prop from ReadButton component in BookmarkCardActions
- Improves user guidance and usability as requested in issue #40

## Implementation Details
The ReadButton component already had comprehensive tooltip functionality built-in using the `InlineTooltip` component. The tooltip was being explicitly disabled in bookmark cards via the `showTooltip={false}` prop. 

By removing this prop, the tooltip now shows by default with appropriate text:
- "Mark as read" for unread bookmarks
- "Mark as unread" for read bookmarks

## Test Plan
- [x] TypeScript compilation passes
- [x] ESLint checks pass
- [x] Tooltip appears on hover for read buttons in bookmark cards
- [x] Tooltip text is contextually appropriate based on read state

Fixes #40