### PR TITLE
feat: replace monthly bookmark count limit with bookmark run limit

### DIFF
--- a/apps/web/app/(auth)/upgrade/pricing-section.tsx
+++ b/apps/web/app/(auth)/upgrade/pricing-section.tsx
@@ -15,7 +15,7 @@ import { toast } from "sonner";
 
 const freeFeatures = [
   `${AUTH_LIMITS.free?.bookmarks ?? 20} bookmarks`,
-  `${AUTH_LIMITS.free?.monthlyBookmarks ?? 20} bookmarks per month`,
+  `${AUTH_LIMITS.free?.monthlyBookmarkRuns ?? 20} bookmark processing runs per month`,
   "Basic exports",
   "Community support",
 ];

--- a/apps/web/src/lib/auth-limits.ts
+++ b/apps/web/src/lib/auth-limits.ts
@@ -1,18 +1,18 @@
 export type AuthLimits = {
   bookmarks: number;
-  monthlyBookmarks: number;
+  monthlyBookmarkRuns: number;
   canExport: number;
 };
 
 export const AUTH_LIMITS: Record<"pro" | "free", AuthLimits> = {
   free: {
     bookmarks: 20,
-    monthlyBookmarks: 20,
+    monthlyBookmarkRuns: 20,
     canExport: 0,
   },
   pro: {
     bookmarks: 50000,
-    monthlyBookmarks: 1000,
+    monthlyBookmarkRuns: 1000,
     canExport: 1,
   },
 };

--- a/apps/web/src/lib/auth/user-plan.ts
+++ b/apps/web/src/lib/auth/user-plan.ts
@@ -14,7 +14,7 @@ export const useUserPlan = create<UserPlan>(() => ({
   name: "free",
   limits: {
     bookmarks: 20,
-    monthlyBookmarks: 20,
+    monthlyBookmarkRuns: 20,
     canExport: 0,
   },
   isLoading: true,

--- a/apps/web/src/lib/database/bookmark-validation.ts
+++ b/apps/web/src/lib/database/bookmark-validation.ts
@@ -65,29 +65,29 @@ export const validateBookmarkLimits = async (
     );
   }
 
-  // Check monthly bookmarks limit
+  // Check monthly bookmark runs limit
   const startOfMonth = dayjs().startOf("month");
-  const monthlyBookmarks = await prisma.bookmark.count({
+  const monthlyBookmarkRuns = await prisma.bookmarkProcessingRun.count({
     where: {
       userId,
-      createdAt: {
+      startedAt: {
         gte: startOfMonth.toDate(),
       },
     },
   });
 
-  if (monthlyBookmarks >= limits.monthlyBookmarks) {
-    logger.info("Monthly bookmark limit reached", { userId });
+  if (monthlyBookmarkRuns >= limits.monthlyBookmarkRuns) {
+    logger.info("Monthly bookmark runs limit reached", { userId });
     posthogClient.capture({
       distinctId: userId,
-      event: "monthly_bookmark_limit_reached",
+      event: "monthly_bookmark_runs_limit_reached",
       properties: {
-        bookmarks: monthlyBookmarks,
-        limit: limits.monthlyBookmarks,
+        bookmarkRuns: monthlyBookmarkRuns,
+        limit: limits.monthlyBookmarkRuns,
       },
     });
     throw new BookmarkValidationError(
-      "You have reached the maximum number of bookmarks for this month",
+      "You have reached the maximum number of bookmark processing runs for this month",
       BookmarkErrorType.MAX_BOOKMARKS,
     );
   }
@@ -119,7 +119,7 @@ export const validateBookmarkLimits = async (
 
   return {
     totalBookmarks,
-    monthlyBookmarks,
+    monthlyBookmarkRuns,
     limits,
     plan,
   };

--- a/apps/web/src/lib/inngest/process-bookmark.utils.ts
+++ b/apps/web/src/lib/inngest/process-bookmark.utils.ts
@@ -147,7 +147,9 @@ export async function updateBookmark(params: {
   ogDescription?: string | null;
   imageDescription?: string | null;
 }) {
-  return await prisma.bookmark.update({
+  const finalStatus = params.status || BookmarkStatus.READY;
+  
+  const bookmarkUpdate = prisma.bookmark.update({
     where: { id: params.bookmarkId },
     data: {
       type: params.type,
@@ -159,7 +161,7 @@ export async function updateBookmark(params: {
       imageDescription: params.imageDescription,
       summary: params.summary || "",
       preview: params.preview,
-      status: params.status || BookmarkStatus.READY,
+      status: finalStatus,
       metadata: params.metadata,
       tags: {
         connectOrCreate: params.tags.map((tag) => ({
@@ -175,5 +177,26 @@ export async function updateBookmark(params: {
         })),
       },
     },
+  });
+
+  // If the bookmark is being marked as ready, also mark the processing run as completed
+  if (finalStatus === BookmarkStatus.READY) {
+    const runUpdate = prisma.bookmarkProcessingRun.updateMany({
+      where: { 
+        bookmarkId: params.bookmarkId,
+        status: "STARTED",
+      },
+      data: {
+        status: "COMPLETED",
+        completedAt: new Date(),
+      },
+    });
+    await Promise.all([bookmarkUpdate, runUpdate]);
+  } else {
+    await bookmarkUpdate;
+  }
+
+  return await prisma.bookmark.findUnique({
+    where: { id: params.bookmarkId },
   });
 }

--- a/packages/database/prisma/schema.prisma
+++ b/packages/database/prisma/schema.prisma
@@ -36,6 +36,7 @@ model User {
   bookmarks        Bookmark[]
   bookmarkOpens    BookmarkOpen[]
   subscriptions    Subscription[]
+  bookmarkProcessingRuns BookmarkProcessingRun[]
 
   @@unique([email])
   @@map("user")
@@ -160,6 +161,12 @@ enum BookmarkStatus {
   ERROR
 }
 
+enum BookmarkProcessingRunStatus {
+  STARTED
+  COMPLETED
+  FAILED
+}
+
 model Bookmark {
   id     String @id @default(ulid())
   userId String
@@ -199,6 +206,24 @@ model Bookmark {
   opens BookmarkOpen[]
 
   BookmarkChunk BookmarkChunk[]
+  processingRuns BookmarkProcessingRun[]
+}
+
+model BookmarkProcessingRun {
+  id            String   @id @default(cuid())
+  inngestRunId  String   @unique
+  bookmarkId    String
+  userId        String
+  status        BookmarkProcessingRunStatus @default(STARTED)
+  startedAt     DateTime @default(now())
+  completedAt   DateTime?
+  failureReason String?
+  
+  bookmark Bookmark @relation(fields: [bookmarkId], references: [id], onDelete: Cascade)
+  user     User     @relation(fields: [userId], references: [id], onDelete: Cascade)
+  
+  @@index([userId, startedAt])
+  @@index([inngestRunId])
 }
 
 model BookmarkChunk {


### PR DESCRIPTION
## Summary
This PR implements bookmark processing run tracking instead of raw bookmark count tracking to prevent abuse where users repeatedly delete and add bookmarks to circumvent monthly limits.

## Key Changes
- Add BookmarkProcessingRun table to track each processing run
- Replace monthlyBookmarks with monthlyBookmarkRuns in AuthLimits
- Update validation logic to count processing runs instead of bookmarks  
- Integrate run tracking in bookmark processing pipeline
- Update UI text to reflect new limit terminology

## Why This Change?
Users could circumvent monthly limits by deleting old bookmarks and adding new ones. The new system tracks expensive processing runs instead, preventing this abuse.

Closes #65