### PR TITLE
feat: Add account deletion functionality to mobile app

### DIFF
--- a/apps/mobile/app/(tabs)/settings.tsx
+++ b/apps/mobile/app/(tabs)/settings.tsx
@@ -1,7 +1,7 @@
-import { Book, HelpCircle, LogOut, Moon, Sun, User } from "@tamagui/lucide-icons";
+import { Book, HelpCircle, LogOut, Moon, Sun, Trash2, User } from "@tamagui/lucide-icons";
 import * as WebBrowser from "expo-web-browser";
-import { Alert } from "react-native";
-import { Button, Card, Separator, Text, XStack, YStack } from "tamagui";
+import { Alert, Linking } from "react-native";
+import { AlertDialog, Button, Card, Separator, Text, XStack, YStack } from "tamagui";
 
 import { useAuth } from "../../src/contexts/AuthContext";
 import { useAppTheme } from "../_layout";
@@ -27,12 +27,20 @@ export default function TabTwoScreen() {
         onPress: async () => {
           try {
             await signOut();
-          } catch (error) {
+          } catch {
             Alert.alert("Error", "Failed to sign out");
           }
         },
       },
     ]);
+  };
+
+  const handleDeleteAccountSteps = async () => {
+    try {
+      await signOut();
+    } catch {
+      Alert.alert("Error", "Failed to sign out");
+    }
   };
 
   if (!user) {
@@ -148,6 +156,111 @@ export default function TabTwoScreen() {
             </Text>
           </XStack>
         </Button>
+
+        <AlertDialog>
+          <AlertDialog.Trigger asChild>
+            <Button
+              size="$4"
+              backgroundColor="$backgroundTransparent"
+              borderWidth={1}
+              borderColor="$red8"
+              justifyContent="flex-start"
+            >
+              <XStack alignItems="center" gap="$3">
+                <Trash2 size={20} color="$red10" />
+                <Text fontSize="$4" color="$red10">
+                  Delete Account
+                </Text>
+              </XStack>
+            </Button>
+          </AlertDialog.Trigger>
+
+          <AlertDialog.Portal>
+            <AlertDialog.Overlay
+              key="overlay"
+              animation="quick"
+              opacity={0.5}
+              enterStyle={{ opacity: 0 }}
+              exitStyle={{ opacity: 0 }}
+            />
+            <AlertDialog.Content
+              bordered
+              elevate
+              key="content"
+              animation={[
+                "quick",
+                {
+                  opacity: {
+                    overshootClamping: true,
+                  },
+                },
+              ]}
+              enterStyle={{ x: 0, y: -20, opacity: 0, scale: 0.9 }}
+              exitStyle={{ x: 0, y: 10, opacity: 0, scale: 0.95 }}
+              x={0}
+              scale={1}
+              opacity={1}
+              y={0}
+            >
+              <YStack gap="$3">
+                <AlertDialog.Title fontSize="$6" fontWeight="bold">
+                  Delete Account
+                </AlertDialog.Title>
+                <AlertDialog.Description fontSize="$4" color="$gray10" lineHeight="$5">
+                  To delete your account, please follow these steps:
+                </AlertDialog.Description>
+                
+                <YStack gap="$3" marginVertical="$2">
+                  <XStack gap="$2" alignItems="flex-start">
+                    <Text fontSize="$4" fontWeight="bold" color="$color" minWidth={20}>1.</Text>
+                    <Text fontSize="$4" color="$color" flex={1}>
+                      Go to{" "}
+                      <Text 
+                        fontSize="$4" 
+                        color="$blue10" 
+                        textDecorationLine="underline"
+                        onPress={() => Linking.openURL("https://saveit.now/signin?redirectUrl=https://saveit.now/account")}
+                      >
+                        https://saveit.now/signin?redirectUrl=https://saveit.now/account
+                      </Text>
+                    </Text>
+                  </XStack>
+                  
+                  <XStack gap="$2" alignItems="flex-start">
+                    <Text fontSize="$4" fontWeight="bold" color="$color" minWidth={20}>2.</Text>
+                    <Text fontSize="$4" color="$color" flex={1}>
+                      Click on the delete account button
+                    </Text>
+                  </XStack>
+                  
+                  <XStack gap="$2" alignItems="flex-start">
+                    <Text fontSize="$4" fontWeight="bold" color="$color" minWidth={20}>3.</Text>
+                    <Text fontSize="$4" color="$color" flex={1}>
+                      Click on the link in your email to confirm
+                    </Text>
+                  </XStack>
+                </YStack>
+
+                <Text fontSize="$3" color="$gray10" fontStyle="italic" marginTop="$2">
+                  Then your account will be deleted. The app will show an unlogged state after you follow these steps.
+                </Text>
+
+                <XStack gap="$3" justifyContent="flex-end" marginTop="$4">
+                  <AlertDialog.Cancel asChild>
+                    <Button size="$3" variant="outlined">
+                      <Text>Cancel</Text>
+                    </Button>
+                  </AlertDialog.Cancel>
+                  <AlertDialog.Action asChild>
+                    <Button theme="red" size="$3" onPress={handleDeleteAccountSteps}>
+                      <Text color="white">Got it</Text>
+                    </Button>
+                  </AlertDialog.Action>
+                </XStack>
+              </YStack>
+            </AlertDialog.Content>
+          </AlertDialog.Portal>
+        </AlertDialog>
       </YStack>
 
       <Button

--- a/apps/web/app/(auth)/signin/page.tsx
+++ b/apps/web/app/(auth)/signin/page.tsx
@@ -12,12 +12,13 @@ import {
   CardTitle,
 } from "@workspace/ui/components/card";
 import { Typography } from "@workspace/ui/components/typography";
-import { useRouter } from "next/navigation";
+import { useRouter, useSearchParams } from "next/navigation";
 import { toast } from "sonner";
 
 export default function SignInPage() {
   const router = useRouter();
   const session = useSession();
+  const searchParams = useSearchParams();
 
   return (
     <MaxWidthContainer
@@ -117,7 +118,7 @@ export default function SignInPage() {
               return result.data.user;
             }}
             onSuccess={() => {
-              router.push("/app");
+              router.push(searchParams.get("redirectUrl") || "/app");
               session.refetch();
             }}
             onError={(error) => toast.error(error)}


### PR DESCRIPTION
## Summary
- Adds "Delete Account" button to mobile app settings view
- Implements custom AlertDialog with step-by-step deletion instructions
- Includes clickable link to web account deletion page
- Signs out user after confirming they understand the deletion steps
- Adds support for redirect URL parameter in web signin page

## Apple App Store Compliance
This implementation addresses **App Store Guideline 5.1.1(v) - Data Collection and Storage** which requires apps that support account creation to also offer account deletion functionality.

## Key Features
✅ Clear step-by-step instructions for account deletion
✅ Direct link to web deletion page (https://saveit.now/signin?redirectUrl=https://saveit.now/account)
✅ User confirmation before logout
✅ App shows unlogged state after deletion process
✅ Follows existing UI patterns and styling
✅ Uses Tamagui AlertDialog for better UX than native alerts

## Test Plan
- [x] Button appears in settings view for logged-in users
- [x] AlertDialog opens with correct instructions
- [x] Link opens web browser to deletion page
- [x] "Got it" button signs out user and shows unlogged state
- [x] Cancel button closes dialog without action
- [x] Linting and TypeScript checks pass

## Technical Implementation
- Uses Tamagui `AlertDialog` component for native-like UX
- Follows existing settings UI patterns with proper theming
- Leverages existing `signOut()` method from AuthContext
- Adds redirect URL support to web signin page for seamless flow
- Clean, accessible code with proper error handling

This change ensures the mobile app meets Apple's requirements for account deletion while providing a clear, user-friendly experience.