### PR TITLE
fix: prevent duplicate limit reached emails

### DIFF
--- a/apps/web/src/lib/database/bookmark-validation.ts
+++ b/apps/web/src/lib/database/bookmark-validation.ts
@@ -40,13 +40,20 @@ export const validateBookmarkLimits = async (
   });
 
   if (plan === "free" && totalBookmarks >= 19) {
-    logger.info("Sending email to user", { userId });
-    inngest.send({
-      name: "marketing/email-on-limit-reached",
-      data: {
-        userId,
-      },
-    });
+    const { hasLimitEmailBeenSent } = await import("./user-metadata.utils");
+    const emailAlreadySent = await hasLimitEmailBeenSent(userId);
+
+    if (!emailAlreadySent) {
+      logger.info("Sending limit reached email to user", { userId });
+      inngest.send({
+        name: "marketing/email-on-limit-reached",
+        data: {
+          userId,
+        },
+      });
+    } else {
+      logger.info("Limit email already sent", { userId });
+    }
   }
 
   if (totalBookmarks >= limits.bookmarks) {

--- a/apps/web/src/lib/database/user-metadata.utils.ts
+++ b/apps/web/src/lib/database/user-metadata.utils.ts
@@ -1,0 +1,46 @@
+import { prisma } from "@workspace/database";
+import { z } from "zod";
+
+const UserMetadataSchema = z.object({
+  limitEmailSentAt: z.string().optional(),
+}).passthrough();
+
+export type UserMetadata = z.infer<typeof UserMetadataSchema>;
+
+export const getUserMetadata = async (userId: string): Promise<UserMetadata> => {
+  const user = await prisma.user.findUnique({
+    where: { id: userId },
+    select: { metadata: true },
+  });
+
+  if (!user?.metadata) {
+    return {};
+  }
+
+  const result = UserMetadataSchema.safeParse(user.metadata);
+  return result.success ? result.data : {};
+};
+
+export const updateUserMetadata = async (
+  userId: string,
+  updates: Partial<UserMetadata>
+): Promise<void> => {
+  const currentMetadata = await getUserMetadata(userId);
+  const updatedMetadata = { ...currentMetadata, ...updates };
+
+  await prisma.user.update({
+    where: { id: userId },
+    data: { metadata: updatedMetadata as any },
+  });
+};
+
+export const setLimitEmailSent = async (userId: string): Promise<void> => {
+  await updateUserMetadata(userId, {
+    limitEmailSentAt: new Date().toISOString(),
+  });
+};
+
+export const hasLimitEmailBeenSent = async (userId: string): Promise<boolean> => {
+  const metadata = await getUserMetadata(userId);
+  return !!metadata.limitEmailSentAt;
+};

--- a/apps/web/src/lib/inngest/marketing/marketing-emails-on-limit-reached.job.ts
+++ b/apps/web/src/lib/inngest/marketing/marketing-emails-on-limit-reached.job.ts
@@ -88,6 +88,11 @@ export const marketingEmailsOnLimitReachedJob = inngest.createFunction(
       });
     });
 
+    await step.run("mark-email-sent", async () => {
+      const { setLimitEmailSent } = await import("../../database/user-metadata.utils");
+      await setLimitEmailSent(userId);
+    });
+
     await step.sleep("wait-1-day-after-discount", "1d");
 
     await step.run("send-discount-reminder", async () => {

--- a/packages/database/CLAUDE.md
+++ b/packages/database/CLAUDE.md
@@ -1,1 +1,11 @@
 Always run `prisma migrate dev` when updating the schema. Always CREATE a migration and regenerate the type for the CI. Important check.
+
+## Workflow modification
+
+🚨 **CRITICAL RULE - ALWAYS FOLLOW THIS** 🚨
+
+**AFTER UPDATED THE SCHEMA OF THE DATABASE** you NEED to always run :
+
+- `pnpm prisma migrate dev --name <migration_name>` to create a migration
+
+This is **NON-NEGOTIABLE**. Do not skip this step under any circumstances. Making the migration ensures that the database schema is up-to-date and consistent across all environments.

--- a/packages/database/prisma/migrations/20250919004117_add_metadtata_field_on_user/migration.sql
+++ b/packages/database/prisma/migrations/20250919004117_add_metadtata_field_on_user/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "public"."user" ADD COLUMN     "metadata" JSONB;

--- a/packages/database/prisma/schema.prisma
+++ b/packages/database/prisma/schema.prisma
@@ -30,6 +30,7 @@ model User {
   banExpires             DateTime?
   onboarding             Boolean                 @default(false)
   unsubscribed           Boolean                 @default(false)
+  metadata               Json?
   sessions               Session[]
   accounts               Account[]
   apikeys                Apikey[]


### PR DESCRIPTION
## Summary
• Add metadata field to User model to track email status
• Check if limit email already sent before triggering new emails
• Mark email as sent after successful delivery
• Create type-safe utilities for user metadata management

## Type
fix