### PR TITLE
refactor: remove unused BLOG and POST bookmark types

### DIFF
--- a/.claude/commands/fix-web-tests.md
+++ b/.claude/commands/fix-web-tests.md
@@ -1,0 +1,57 @@
+---
+description: Fix and stabilize web tests until they pass, then commit changes
+allowed-tools: Bash(pnpm :*), Bash(git :*), Bash(gh :*), Read, Edit, MultiEdit, Task
+---
+
+You are a test fixing specialist. Your mission is to run web tests, identify failures, fix them systematically, and ensure all tests pass before committing.
+
+## Workflow
+
+1. **NAVIGATE**: Change to web app directory
+   - `cd apps/web`
+   - Verify location with `pwd`
+
+2. **INITIAL RUN**: Execute both test suites
+   - `pnpm test:ci` (unit tests)
+   - `pnpm test:e2e:ci` (end-to-end tests)
+   - **CRITICAL**: Run both commands and capture all output
+
+3. **ANALYZE FAILURES**: If tests fail, identify issues
+   - Parse test output for specific failures
+   - Identify failing test files and error messages
+   - **PRIORITY**: Focus on actual test logic, not flaky infrastructure
+
+4. **FIX SYSTEMATICALLY**: Resolve each failure
+   - Read failing test files to understand issues
+   - Fix test logic, assertions, or setup problems
+   - **AVOID**: Commenting out tests - fix the root cause
+   - **STAY IN SCOPE**: Only fix tests, don't modify core application logic
+
+5. **RETRY TESTS**: Re-run tests after fixes
+   - `pnpm test:ci` for unit test fixes
+   - `pnpm test:e2e:ci` for e2e test fixes
+   - **LOOP**: Repeat steps 3-5 until all tests pass
+
+6. **VERIFY SUCCESS**: Confirm clean test run
+   - Both test suites must pass completely
+   - **BEFORE COMMIT**: Ensure no remaining failures
+
+7. **COMMIT CHANGES**: Save test fixes
+   - `git add -A` to stage all changes
+   - `git commit -m "fix: resolve failing web tests"`
+   - **REQUIRED**: Commit message must follow conventional commits
+
+8. **PUSH CHANGES**: Deploy fixes
+   - `git push` to remote repository
+   - Verify successful push
+
+## Execution Rules
+
+- **NON-NEGOTIABLE**: All tests must pass before committing
+- **MAX ATTEMPTS**: Stop after 5 fix cycles if tests still fail
+- **FOCUS**: Fix tests only, don't refactor unrelated code
+- **NO SKIPPING**: Don't skip or disable failing tests
+
+## Priority
+
+Test stability over speed. Ensure robust, passing test suite.

--- a/apps/web/__tests__/search-helpers.test.ts
+++ b/apps/web/__tests__/search-helpers.test.ts
@@ -133,7 +133,7 @@ describe("search-helpers", () => {
       expect(result).toEqual({
         read: true,
         type: {
-          in: ["ARTICLE", "BLOG", "YOUTUBE"],
+          in: ["ARTICLE", "YOUTUBE"],
         },
       });
     });
@@ -143,7 +143,7 @@ describe("search-helpers", () => {
       expect(result).toEqual({
         read: false,
         type: {
-          in: ["ARTICLE", "BLOG", "YOUTUBE"],
+          in: ["ARTICLE", "YOUTUBE"],
         },
       });
     });
@@ -162,7 +162,7 @@ describe("search-helpers", () => {
           {
             read: true,
             type: {
-              in: ["ARTICLE", "BLOG", "YOUTUBE"],
+              in: ["ARTICLE", "YOUTUBE"],
             },
           },
           {

--- a/apps/web/__tests__/type-filter-utils.test.ts
+++ b/apps/web/__tests__/type-filter-utils.test.ts
@@ -353,9 +353,7 @@ describe("type-filter-utils", () => {
   describe("getTypeDisplayName", () => {
     it("should return correct display names for all types", () => {
       expect(getTypeDisplayName(BookmarkType.VIDEO)).toBe("Video");
-      expect(getTypeDisplayName(BookmarkType.BLOG)).toBe("Blog");
       expect(getTypeDisplayName(BookmarkType.PAGE)).toBe("Page");
-      expect(getTypeDisplayName(BookmarkType.POST)).toBe("Post");
       expect(getTypeDisplayName(BookmarkType.IMAGE)).toBe("Image");
       expect(getTypeDisplayName(BookmarkType.YOUTUBE)).toBe("YouTube");
       expect(getTypeDisplayName(BookmarkType.TWEET)).toBe("Tweet");
@@ -372,9 +370,7 @@ describe("type-filter-utils", () => {
   describe("getTypeColor", () => {
     it("should return color classes for all types", () => {
       expect(getTypeColor(BookmarkType.VIDEO)).toContain("bg-red-100");
-      expect(getTypeColor(BookmarkType.BLOG)).toContain("bg-blue-100");
       expect(getTypeColor(BookmarkType.PAGE)).toContain("bg-gray-100");
-      expect(getTypeColor(BookmarkType.POST)).toContain("bg-green-100");
       expect(getTypeColor(BookmarkType.IMAGE)).toContain("bg-purple-100");
       expect(getTypeColor(BookmarkType.YOUTUBE)).toContain("bg-red-100");
       expect(getTypeColor(BookmarkType.TWEET)).toContain("bg-blue-100");

--- a/apps/web/__tests__/type-filter-utils.test.ts
+++ b/apps/web/__tests__/type-filter-utils.test.ts
@@ -17,9 +17,9 @@ import {
 describe("type-filter-utils", () => {
   describe("parseAtMention", () => {
     it("should parse @ mention at cursor position", () => {
-      const result = parseAtMention("Search @BLOG", 12);
+      const result = parseAtMention("Search @PAGE", 12);
       expect(result).toEqual({
-        mention: "BLOG",
+        mention: "PAGE",
         startIndex: 7,
         endIndex: 12,
         type: "type",
@@ -39,19 +39,19 @@ describe("type-filter-utils", () => {
     });
 
     it("should return null if no @ found", () => {
-      const result = parseAtMention("Search BLOG", 11);
+      const result = parseAtMention("Search PAGE", 11);
       expect(result).toBeNull();
     });
 
     it("should return null if space after @", () => {
-      const result = parseAtMention("Search @ BLOG", 13);
+      const result = parseAtMention("Search @ PAGE", 13);
       expect(result).toBeNull();
     });
 
     it("should handle @ at beginning", () => {
-      const result = parseAtMention("@BLOG", 5);
+      const result = parseAtMention("@PAGE", 5);
       expect(result).toEqual({
-        mention: "BLOG",
+        mention: "PAGE",
         startIndex: 0,
         endIndex: 5,
         type: "type",
@@ -71,7 +71,7 @@ describe("type-filter-utils", () => {
     });
 
     it("should use last @ if multiple", () => {
-      const result = parseAtMention("@BLOG @ARTICLE", 14);
+      const result = parseAtMention("@PAGE @ARTICLE", 14);
       expect(result).toEqual({
         mention: "ARTICLE",
         startIndex: 6,
@@ -82,7 +82,7 @@ describe("type-filter-utils", () => {
     });
 
     it("should handle cursor in middle of word", () => {
-      const result = parseAtMention("Search @BLOG more", 10);
+      const result = parseAtMention("Search @PAGE more", 10);
       expect(result).toEqual({
         mention: "BL",
         startIndex: 7,
@@ -93,7 +93,7 @@ describe("type-filter-utils", () => {
     });
 
     it("should handle cursor position 0", () => {
-      const result = parseAtMention("@BLOG", 0);
+      const result = parseAtMention("@PAGE", 0);
       expect(result).toBeNull();
     });
   });
@@ -303,17 +303,17 @@ describe("type-filter-utils", () => {
 
   describe("removeAtMention", () => {
     it("should remove @ mention from string", () => {
-      const result = removeAtMention("Search @BLOG content", 7, 12);
+      const result = removeAtMention("Search @PAGE content", 7, 12);
       expect(result).toBe("Search  content");
     });
 
     it("should remove @ mention at beginning", () => {
-      const result = removeAtMention("@BLOG content", 0, 5);
+      const result = removeAtMention("@PAGE content", 0, 5);
       expect(result).toBe(" content");
     });
 
     it("should remove @ mention at end", () => {
-      const result = removeAtMention("Search @BLOG", 7, 12);
+      const result = removeAtMention("Search @PAGE", 7, 12);
       expect(result).toBe("Search ");
     });
 
@@ -325,17 +325,17 @@ describe("type-filter-utils", () => {
 
   describe("removeMention", () => {
     it("should remove mention from string", () => {
-      const result = removeMention("Search @BLOG content", 7, 12);
+      const result = removeMention("Search @PAGE content", 7, 12);
       expect(result).toBe("Search  content");
     });
 
     it("should remove mention at beginning", () => {
-      const result = removeMention("@BLOG content", 0, 5);
+      const result = removeMention("@PAGE content", 0, 5);
       expect(result).toBe(" content");
     });
 
     it("should remove mention at end", () => {
-      const result = removeMention("Search @BLOG", 7, 12);
+      const result = removeMention("Search @PAGE", 7, 12);
       expect(result).toBe("Search ");
     });
 
@@ -345,7 +345,7 @@ describe("type-filter-utils", () => {
     });
 
     it("should handle full string removal", () => {
-      const result = removeMention("@BLOG", 0, 5);
+      const result = removeMention("@PAGE", 0, 5);
       expect(result).toBe("");
     });
   });

--- a/apps/web/__tests__/type-filter-utils.test.ts
+++ b/apps/web/__tests__/type-filter-utils.test.ts
@@ -84,7 +84,7 @@ describe("type-filter-utils", () => {
     it("should handle cursor in middle of word", () => {
       const result = parseAtMention("Search @PAGE more", 10);
       expect(result).toEqual({
-        mention: "BL",
+        mention: "PA",
         startIndex: 7,
         endIndex: 10,
         type: "type",

--- a/apps/web/app/(layout)/exports/export-form.tsx
+++ b/apps/web/app/(layout)/exports/export-form.tsx
@@ -90,7 +90,7 @@ export function ExportForm({ className }: ExportFormProps) {
                   <li>Title - The bookmark title</li>
                   <li>Description - Open Graph description</li>
                   <li>Summary - AI-generated summary</li>
-                  <li>Type - Bookmark type (VIDEO, BLOG, PAGE, etc.)</li>
+                  <li>Type - Bookmark type (VIDEO, ARTICLE, PAGE, etc.)</li>
                   <li>URL - The original bookmark URL</li>
                 </ul>
               </div>

--- a/apps/web/app/app/bookmark-card/index.tsx
+++ b/apps/web/app/app/bookmark-card/index.tsx
@@ -45,7 +45,6 @@ export const BookmarkCard = ({ bookmark }: BookmarkCardProps) => {
       return <BookmarkCardProduct bookmark={bookmark} />;
 
     case "PAGE":
-    case "BLOG":
     case "ARTICLE":
     default:
       return <BookmarkCardPage bookmark={bookmark} />;

--- a/apps/web/app/app/components/filter-list.tsx
+++ b/apps/web/app/app/components/filter-list.tsx
@@ -38,8 +38,6 @@ export const FilterList = ({ query }: { query?: string }) => {
       {showTypeList &&
         filteredTypes.map((type) => {
           if (type === "VIDEO") return null;
-          if (type === "BLOG") return null;
-          if (type === "POST") return null;
           return (
             <Badge
               key={`type-${type}`}

--- a/apps/web/app/app/utils/type-filter-utils.ts
+++ b/apps/web/app/app/utils/type-filter-utils.ts
@@ -111,9 +111,7 @@ export const removeMention = (
 export const getTypeDisplayName = (type: BookmarkType): string => {
   const displayNames: Record<BookmarkType, string> = {
     VIDEO: "Video",
-    BLOG: "Blog",
     PAGE: "Page",
-    POST: "Post",
     IMAGE: "Image",
     YOUTUBE: "YouTube",
     TWEET: "Tweet",
@@ -127,9 +125,7 @@ export const getTypeColor = (type: BookmarkType): string => {
   const colors: Record<BookmarkType, string> = {
     VIDEO:
       "bg-red-100 text-red-700 hover:bg-red-200 dark:bg-red-900/20 dark:text-red-400 dark:hover:bg-red-900/30",
-    BLOG: "bg-blue-100 text-blue-700 hover:bg-blue-200 dark:bg-blue-900/20 dark:text-blue-400 dark:hover:bg-blue-900/30",
     PAGE: "bg-gray-100 text-gray-700 hover:bg-gray-200 dark:bg-gray-800/50 dark:text-gray-300 dark:hover:bg-gray-800/70",
-    POST: "bg-green-100 text-green-700 hover:bg-green-200 dark:bg-green-900/20 dark:text-green-400 dark:hover:bg-green-900/30",
     IMAGE:
       "bg-purple-100 text-purple-700 hover:bg-purple-200 dark:bg-purple-900/20 dark:text-purple-400 dark:hover:bg-purple-900/30",
     YOUTUBE:

--- a/apps/web/src/features/bookmarks/bookmark-content-view.tsx
+++ b/apps/web/src/features/bookmarks/bookmark-content-view.tsx
@@ -31,7 +31,7 @@ export const BookmarkContentView = ({
           <div className="flex size-8 items-center justify-center rounded border shrink-0">
             <BookmarkFavicon
               faviconUrl={bookmark.faviconUrl ?? undefined}
-              bookmarkType={bookmark.type ?? "BLOG"}
+              bookmarkType={bookmark.type ?? "PAGE"}
             />
           </div>
           <div className="flex flex-col gap-1 min-w-0 flex-1">

--- a/apps/web/src/lib/search/search-helpers.ts
+++ b/apps/web/src/lib/search/search-helpers.ts
@@ -166,7 +166,6 @@ export function isSearchQuery(query?: string): boolean {
 
 const READABLE_BOOKMARK = [
   "ARTICLE",
-  "BLOG",
   "YOUTUBE",
 ] satisfies BookmarkType[];
 

--- a/apps/web/test/vitest.setup.ts
+++ b/apps/web/test/vitest.setup.ts
@@ -142,14 +142,13 @@ vi.mock("@workspace/database", () => ({
   prisma: mockDeep(),
   BookmarkType: {
     VIDEO: "VIDEO",
-    BLOG: "BLOG",
     PAGE: "PAGE",
-    POST: "POST",
     IMAGE: "IMAGE",
     YOUTUBE: "YOUTUBE",
     TWEET: "TWEET",
     ARTICLE: "ARTICLE",
     PDF: "PDF",
+    PRODUCT: "PRODUCT",
   },
   BookmarkStatus: {
     PROCESSING: "PROCESSING",

--- a/packages/database/prisma/migrations/20250920094854_remove_unused_bookmark_types/migration.sql
+++ b/packages/database/prisma/migrations/20250920094854_remove_unused_bookmark_types/migration.sql
@@ -1,0 +1,14 @@
+-- AlterEnum
+-- Remove unused BLOG and POST values from BookmarkType enum
+
+-- Create a new enum type with only the values we want to keep
+CREATE TYPE "BookmarkType_new" AS ENUM ('VIDEO', 'ARTICLE', 'PAGE', 'IMAGE', 'YOUTUBE', 'TWEET', 'PDF', 'PRODUCT');
+
+-- Update the Bookmark table to use the new enum type
+ALTER TABLE "Bookmark" ALTER COLUMN "type" TYPE "BookmarkType_new" USING ("type"::text::"BookmarkType_new");
+
+-- Drop the old enum type
+DROP TYPE "BookmarkType";
+
+-- Rename the new enum type to the original name
+ALTER TYPE "BookmarkType_new" RENAME TO "BookmarkType";

--- a/packages/database/prisma/schema.prisma
+++ b/packages/database/prisma/schema.prisma
@@ -147,10 +147,8 @@ model BookmarkTag {
 
 enum BookmarkType {
   VIDEO
-  BLOG
   ARTICLE
   PAGE
-  POST
   IMAGE
   YOUTUBE
   TWEET


### PR DESCRIPTION
## Summary
• Remove unused BLOG and POST enum values from BookmarkType
• Create database migration for enum cleanup
• Update utility functions, tests, and components
• Fix TypeScript errors and simplify filter logic

## Type
refactor