### PR TITLE
chore: update AI models to latest

### DIFF
--- a/apps/web/__tests__/ai-model-migration.test.ts
+++ b/apps/web/__tests__/ai-model-migration.test.ts
@@ -33,6 +33,16 @@ function readProjectFile(relativePath: string) {
 }
 
 describe("AI model migration", () => {
+  it("uses the latest OpenAI generation defaults while keeping the existing embedding model", () => {
+    const content = readProjectFile("src/lib/openai.ts");
+
+    expect(content).toContain('cheap: openai("gpt-5.4-mini")');
+    expect(content).toContain('normal: openai("gpt-5.5")');
+    expect(content).toContain(
+      'embedding: openai.embedding("text-embedding-3-small")',
+    );
+  });
+
   it("keeps bookmark processing and search off OpenAI generation and embedding models", () => {
     const offenders = GEMINI_PROCESSING_FILES.flatMap((relativePath) => {
       const content = readProjectFile(relativePath);

--- a/apps/web/__tests__/gemini-models.test.ts
+++ b/apps/web/__tests__/gemini-models.test.ts
@@ -5,11 +5,18 @@ import {
   GEMINI_MODEL_IDS,
   GEMINI_QUERY_EMBEDDING_PROVIDER_OPTIONS,
 } from "../src/lib/gemini";
+import { CHAT_MODEL } from "../src/lib/chat/gemini-model";
 
 describe("Gemini model configuration", () => {
-  it("uses Gemini Flash-Lite for cheap generation and Gemini 3 Pro for normal generation", () => {
+  it("uses Gemini Flash-Lite for cheap generation and Gemini 3.1 Pro for normal generation", () => {
     expect(GEMINI_MODEL_IDS.cheap).toBe("gemini-3.1-flash-lite");
     expect(GEMINI_MODEL_IDS.normal).toBe("gemini-3.1-pro-preview");
+  });
+
+  it("uses the central normal Gemini model for chat", () => {
+    expect((CHAT_MODEL as { modelId: string }).modelId).toBe(
+      GEMINI_MODEL_IDS.normal,
+    );
   });
 
   it("keeps Gemini embeddings compatible with existing 1536-dimension pgvector columns", () => {

--- a/apps/web/src/lib/chat/gemini-model.ts
+++ b/apps/web/src/lib/chat/gemini-model.ts
@@ -1,8 +1,10 @@
 import { createGoogleGenerativeAI } from "@ai-sdk/google";
 import type { GoogleGenerativeAIProviderOptions } from "@ai-sdk/google";
+import { GEMINI_MODEL_IDS } from "../gemini";
+
 const google = createGoogleGenerativeAI({});
 
-export const CHAT_MODEL = google("gemini-3-flash-preview");
+export const CHAT_MODEL = google(GEMINI_MODEL_IDS.normal);
 
 export type ThinkingConfig = {
   providerOptions?: {

--- a/apps/web/src/lib/openai.ts
+++ b/apps/web/src/lib/openai.ts
@@ -37,7 +37,7 @@ export const OPENAI_MODELS: {
       }),
     }
   : {
-      cheap: openai("gpt-5-mini"),
-      normal: openai("gpt-5"),
+      cheap: openai("gpt-5.4-mini"),
+      normal: openai("gpt-5.5"),
       embedding: openai.embedding("text-embedding-3-small"),
     };


### PR DESCRIPTION
Update SaveIt runtime AI model defaults to latest IDs.

Changes:
- OpenAI cheap moves to gpt-5.4-mini.
- OpenAI normal moves to gpt-5.5.
- Chat Gemini model now uses the central Gemini normal model.
- Tests updated for the new defaults.

Verification:
- git diff --check
- pnpm --filter web ts
- focused Vitest suite for AI/Gemini models
- pnpm --filter web lint