### PR TITLE
fix(security): require public sharing for bookmark pages

### DIFF
--- a/apps/web/__tests__/public-bookmark-privacy.test.ts
+++ b/apps/web/__tests__/public-bookmark-privacy.test.ts
@@ -1,0 +1,62 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const prismaMock = vi.hoisted(() => ({
+  bookmark: {
+    findFirst: vi.fn(),
+    findUnique: vi.fn(),
+  },
+}));
+
+vi.mock("@workspace/database/client", () => ({
+  prisma: prismaMock,
+}));
+
+import { getPublicBookmark } from "../src/lib/database/get-bookmark";
+import { prisma } from "@workspace/database/client";
+
+const makeBookmark = (overrides: Record<string, unknown> = {}) => ({
+  id: "bookmark_private",
+  userId: "user_private",
+  url: "https://example.com/private",
+  title: "Private bookmark",
+  faviconUrl: null,
+  summary: "Private summary",
+  note: "Sensitive private note",
+  preview: null,
+  ogImageUrl: null,
+  ogDescription: null,
+  type: "ARTICLE",
+  metadata: { markdown: "private article body" },
+  status: "READY",
+  createdAt: new Date("2026-01-01T00:00:00.000Z"),
+  updatedAt: new Date("2026-01-01T00:00:00.000Z"),
+  starred: false,
+  read: false,
+  tags: [],
+  ...overrides,
+});
+
+describe("public bookmark privacy", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("does not expose a bookmark unless the owner enabled their public link", async () => {
+    vi.mocked(prisma.bookmark.findUnique).mockResolvedValue(
+      makeBookmark() as never,
+    );
+    vi.mocked(prisma.bookmark.findFirst).mockResolvedValue(null as never);
+
+    await expect(getPublicBookmark("bookmark_private")).resolves.toBeNull();
+
+    expect(prisma.bookmark.findFirst).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: {
+          id: "bookmark_private",
+          user: { is: { publicLinkEnabled: true } },
+        },
+      }),
+    );
+    expect(prisma.bookmark.findUnique).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/lib/database/get-bookmark.ts
+++ b/apps/web/src/lib/database/get-bookmark.ts
@@ -56,9 +56,10 @@ export const getUserBookmarksByIds = async (
 };
 
 export const getPublicBookmark = async (bookmarkId: string) => {
-  return await prisma.bookmark.findUnique({
+  return await prisma.bookmark.findFirst({
     where: {
       id: bookmarkId,
+      user: { is: { publicLinkEnabled: true } },
     },
     select: SELECT_QUERY,
   });

--- a/apps/web/src/routes/api.og.bookmark.$bookmarkId.ts
+++ b/apps/web/src/routes/api.og.bookmark.$bookmarkId.ts
@@ -11,9 +11,17 @@ const escapeXml = (value: string) =>
 const truncate = (value: string, length: number) =>
   value.length > length ? `${value.slice(0, length - 3)}...` : value;
 
-const GET = async ({ params }: { request: Request; params: { bookmarkId: string } }) => {
-  const bookmark = await prisma.bookmark.findUnique({
-    where: { id: params.bookmarkId },
+const GET = async ({
+  params,
+}: {
+  request: Request;
+  params: { bookmarkId: string };
+}) => {
+  const bookmark = await prisma.bookmark.findFirst({
+    where: {
+      id: params.bookmarkId,
+      user: { is: { publicLinkEnabled: true } },
+    },
     select: {
       title: true,
       url: true,

--- a/apps/web/src/routes/p.$bookmarkId.tsx
+++ b/apps/web/src/routes/p.$bookmarkId.tsx
@@ -30,6 +30,7 @@ const getPublicBookmarkData = createServerFn({ method: "GET" })
     const { prisma } = await import("@workspace/database/client");
     const where = {
       id: { not: data.bookmarkId },
+      user: { is: { publicLinkEnabled: true } },
       status: "READY" as const,
       title: { not: null },
       ...(tagIds.length > 0 && {


### PR DESCRIPTION
## Summary
- Requires the bookmark owner to have public sharing enabled before public bookmark pages or OG metadata resolve by bookmark id.
- Applies the same guard to related public bookmarks.
- Adds a regression test for private-owner bookmark lookup.

## Test Plan
- `pnpm --filter web exec vitest run __tests__/public-bookmark-privacy.test.ts`
- `pnpm exec prettier --check apps/web/__tests__/public-bookmark-privacy.test.ts apps/web/src/routes/api.og.bookmark.$bookmarkId.ts`
- reviewer also ran TypeScript and targeted ESLint successfully after dependency install
- independent review: PASS

## Risk / Rollback
- Medium product behavior risk only if public bookmark IDs were intentionally usable without enabling public sharing. That would be a privacy footgun, so blocking is the right default.
- Rollback by reverting this PR if product semantics need a different explicit per-bookmark visibility model.
