### PR TITLE
fix(security): scope public related bookmarks

### DIFF
--- a/apps/web/__tests__/public-bookmarks-related-security.test.ts
+++ b/apps/web/__tests__/public-bookmarks-related-security.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+import { buildRelatedBookmarksWhere } from "../src/lib/database/public-bookmarks";
+
+describe("public bookmark related results", () => {
+  it("scopes related bookmarks to the public bookmark owner", () => {
+    expect(
+      buildRelatedBookmarksWhere({
+        bookmarkId: "bookmark_public",
+        userId: "owner_user",
+        tagIds: ["tag_shared"],
+      }),
+    ).toMatchObject({
+      userId: "owner_user",
+      id: { not: "bookmark_public" },
+      status: "READY",
+      title: { not: null },
+      tags: { some: { tagId: { in: ["tag_shared"] } } },
+    });
+  });
+});

--- a/apps/web/src/lib/database/public-bookmarks.ts
+++ b/apps/web/src/lib/database/public-bookmarks.ts
@@ -1,0 +1,17 @@
+export const buildRelatedBookmarksWhere = ({
+  bookmarkId,
+  userId,
+  tagIds,
+}: {
+  bookmarkId: string;
+  userId: string;
+  tagIds: string[];
+}) => ({
+  userId,
+  id: { not: bookmarkId },
+  status: "READY" as const,
+  title: { not: null },
+  ...(tagIds.length > 0 && {
+    tags: { some: { tagId: { in: tagIds } } },
+  }),
+});

--- a/apps/web/src/routes/p.$bookmarkId.tsx
+++ b/apps/web/src/routes/p.$bookmarkId.tsx
@@ -13,12 +13,17 @@ import { createServerFn } from "@tanstack/react-start";
 const getPublicBookmarkData = createServerFn({ method: "GET" })
   .validator((data: { bookmarkId: string }) => data)
   .handler(async ({ data }) => {
-    const [{ getUser }, { getPublicBookmark }, { getServerUrl }] =
-      await Promise.all([
-        import("@/lib/auth-session"),
-        import("@/lib/database/get-bookmark"),
-        import("@/lib/server-url"),
-      ]);
+    const [
+      { getUser },
+      { getPublicBookmark },
+      { buildRelatedBookmarksWhere },
+      { getServerUrl },
+    ] = await Promise.all([
+      import("@/lib/auth-session"),
+      import("@/lib/database/get-bookmark"),
+      import("@/lib/database/public-bookmarks"),
+      import("@/lib/server-url"),
+    ]);
     const bookmark = await getPublicBookmark(data.bookmarkId);
     const user = await getUser();
 
@@ -28,14 +33,11 @@ const getPublicBookmarkData = createServerFn({ method: "GET" })
 
     const tagIds = bookmark.tags.map((tag) => tag.tag.id);
     const { prisma } = await import("@workspace/database/client");
-    const where = {
-      id: { not: data.bookmarkId },
-      status: "READY" as const,
-      title: { not: null },
-      ...(tagIds.length > 0 && {
-        tags: { some: { tagId: { in: tagIds } } },
-      }),
-    };
+    const where = buildRelatedBookmarksWhere({
+      bookmarkId: data.bookmarkId,
+      userId: bookmark.userId,
+      tagIds,
+    });
     const relatedBookmarks = await prisma.bookmark.findMany({
       where,
       select: {


### PR DESCRIPTION
## Summary
- Security hotfix from the 2026-07-06 weekly audit.
- Scope public related-bookmark suggestions to the owner of the public bookmark.
- Add a small query-builder helper and regression test so the public related-bookmark predicate keeps `userId` owner scoping.

## Test Plan
- [x] `git diff --check`
- [x] Static added-line scan for hardcoded secrets and dangerous shell/eval/deserialization/SQL patterns
- [x] Spec compliance review: PASS
- [x] Independent code review: PASS
- [ ] `pnpm --filter web exec vitest run __tests__/public-bookmarks-related-security.test.ts --reporter=verbose` blocked locally by Node/V8 WebAssembly OOM
- [ ] `NODE_OPTIONS=--jitless pnpm --filter web ts` ran but failed on unrelated existing TypeScript/Prisma generation issues
- [ ] `NODE_OPTIONS=--jitless pnpm --filter web lint` blocked by WebAssembly requirement in the lint stack

## Risk / Rollback
- Low-risk query tightening. Public pages may show fewer related bookmarks, but should not show other users' bookmarks.
- Rollback by reverting this commit if the related-bookmark UI regresses unexpectedly.

## Known baseline failures
- Local verification is noisy in this cron environment: Vitest and Prisma/lint tooling fail from Node/V8 WebAssembly/OOM and unrelated existing TS/Prisma issues.
