### PR TITLE
fix(ai): align Gemini Embeddings 2 retrieval formatting

### DIFF
--- a/apps/web/__tests__/ai-model-migration.test.ts
+++ b/apps/web/__tests__/ai-model-migration.test.ts
@@ -27,13 +27,17 @@ function readProjectFile(relativePath: string) {
 describe("AI model migration", () => {
   it("uses the active Gemini generation and embedding defaults", () => {
     const gemini = readProjectFile("../../packages/backend/convex/processing/gemini.ts");
-    const embeddings = readProjectFile("../../packages/backend/convex/processing/embeddings.ts");
+    const embeddingFormat = readProjectFile(
+      "../../packages/backend/convex/processing/embedding_format.ts",
+    );
 
     expect(gemini).toContain('cheap: "gemini-3.1-flash-lite"');
     expect(gemini).toContain('normal: "gemini-3.1-pro-preview"');
     expect(gemini).toContain('embedding: "gemini-embedding-2"');
-    expect(embeddings).toContain('EMBEDDING_MODEL = "gemini-embedding-2"');
-    expect(embeddings).toContain('EMBEDDING_MODEL_KEY = "gemini-embedding-2:1536"');
+    expect(embeddingFormat).toContain('EMBEDDING_MODEL = "gemini-embedding-2"');
+    expect(embeddingFormat).toContain(
+      'EMBEDDING_PROMPT_VERSION = "search-result-v1"',
+    );
   });
 
   it("keeps bookmark processing and search off OpenAI generation and embedding models", () => {

--- a/apps/web/__tests__/gemini-models.test.ts
+++ b/apps/web/__tests__/gemini-models.test.ts
@@ -22,19 +22,36 @@ describe("Gemini model configuration", () => {
   });
 
   it("keeps Gemini embeddings on the 1536-dimension Convex vector index", () => {
-    const embeddings = readProjectFile("../../packages/backend/convex/processing/embeddings.ts");
+    const format = readProjectFile(
+      "../../packages/backend/convex/processing/embedding_format.ts",
+    );
     const schema = readProjectFile("../../packages/backend/convex/schema.ts");
 
-    expect(embeddings).toContain('EMBEDDING_MODEL = "gemini-embedding-2"');
-    expect(embeddings).toContain("EMBEDDING_DIMENSIONS = 1536");
-    expect(embeddings).toContain('EMBEDDING_MODEL_KEY = "gemini-embedding-2:1536"');
+    expect(format).toContain('EMBEDDING_MODEL = "gemini-embedding-2"');
+    expect(format).toContain("EMBEDDING_DIMENSIONS = 1536");
+    expect(format).toContain(
+      "EMBEDDING_MODEL_KEY = `${EMBEDDING_MODEL}:${EMBEDDING_DIMENSIONS}:${EMBEDDING_PROMPT_VERSION}`",
+    );
+    expect(format).toContain('EMBEDDING_PROMPT_VERSION = "search-result-v1"');
     expect(schema).toContain("dimensions: 1536");
   });
 
-  it("sets distinct Gemini task types for document and query embeddings", () => {
-    const content = readProjectFile("../../packages/backend/convex/processing/embeddings.ts");
+  it("uses matched Gemini Embeddings 2 prompt formats without unsupported taskType options", () => {
+    const embeddings = readProjectFile(
+      "../../packages/backend/convex/processing/embeddings.ts",
+    );
+    const format = readProjectFile(
+      "../../packages/backend/convex/processing/embedding_format.ts",
+    );
+    const search = readProjectFile(
+      "../../packages/backend/convex/search/actions.ts",
+    );
 
-    expect(content).toContain('taskType: "RETRIEVAL_DOCUMENT"');
-    expect(content).toContain('taskType: "RETRIEVAL_QUERY"');
+    expect(format).toContain("task: search result | query: ${text}");
+    expect(format).toContain(
+      'title: ${title?.trim() || "none"} | text: ${text}',
+    );
+    expect(embeddings).not.toContain("taskType");
+    expect(search).not.toContain("taskType");
   });
 });

--- a/packages/backend/convex/migration/reembed_helpers.ts
+++ b/packages/backend/convex/migration/reembed_helpers.ts
@@ -15,10 +15,11 @@ import {
   query,
 } from "../functions";
 import { throwForbidden } from "../utils/errors";
+import {
+  EMBEDDING_DIMENSIONS as CURRENT_EMBEDDING_DIMENSIONS,
+  EMBEDDING_MODEL_KEY as CURRENT_EMBEDDING_MODEL_KEY,
+} from "../processing/embedding_format";
 
-// Keep in sync with processing/embeddings.ts (cannot import "use node" module here).
-const CURRENT_EMBEDDING_MODEL_KEY = "gemini-embedding-2:1536";
-const CURRENT_EMBEDDING_DIMENSIONS = 1536;
 const DEFAULT_INSPECT_LIMIT = 100;
 const MAX_INSPECT_LIMIT = 500;
 const DEFAULT_BATCH_SIZE = 20;

--- a/packages/backend/convex/processing/embedding_format.test.ts
+++ b/packages/backend/convex/processing/embedding_format.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+import {
+  EMBEDDING_DIMENSIONS,
+  EMBEDDING_MODEL,
+  EMBEDDING_MODEL_KEY,
+  EMBEDDING_PROVIDER_OPTIONS,
+  formatSearchDocument,
+  formatSearchQuery,
+} from "./embedding_format";
+
+describe("Gemini Embeddings 2 retrieval formatting", () => {
+  it("formats search queries with Google's asymmetric retrieval prefix", () => {
+    expect(formatSearchQuery("typescript bookmarks")).toBe(
+      "task: search result | query: typescript bookmarks",
+    );
+  });
+
+  it("formats documents with Google's asymmetric retrieval structure", () => {
+    expect(formatSearchDocument("A guide to TypeScript")).toBe(
+      "title: none | text: A guide to TypeScript",
+    );
+    expect(
+      formatSearchDocument("A guide to TypeScript", "TypeScript handbook"),
+    ).toBe("title: TypeScript handbook | text: A guide to TypeScript");
+  });
+
+  it("versions the prompt format separately while preserving the model and dimensions", () => {
+    expect(EMBEDDING_MODEL).toBe("gemini-embedding-2");
+    expect(EMBEDDING_DIMENSIONS).toBe(1536);
+    expect(EMBEDDING_PROVIDER_OPTIONS).toEqual({
+      google: { outputDimensionality: 1536 },
+    });
+    expect(EMBEDDING_MODEL_KEY).toBe(
+      "gemini-embedding-2:1536:search-result-v1",
+    );
+  });
+});

--- a/packages/backend/convex/processing/embedding_format.ts
+++ b/packages/backend/convex/processing/embedding_format.ts
@@ -1,0 +1,25 @@
+export const EMBEDDING_MODEL = "gemini-embedding-2";
+export const EMBEDDING_DIMENSIONS = 1536;
+
+/**
+ * Version the retrieval prompt contract independently from the provider model.
+ * Every stored document vector and query vector must use the same format.
+ */
+export const EMBEDDING_PROMPT_VERSION = "search-result-v1";
+export const EMBEDDING_MODEL_KEY = `${EMBEDDING_MODEL}:${EMBEDDING_DIMENSIONS}:${EMBEDDING_PROMPT_VERSION}`;
+
+export const EMBEDDING_PROVIDER_OPTIONS = {
+  google: {
+    outputDimensionality: EMBEDDING_DIMENSIONS,
+  },
+} as const;
+
+/** Gemini Embeddings 2 asymmetric retrieval query format. */
+export function formatSearchQuery(text: string): string {
+  return `task: search result | query: ${text}`;
+}
+
+/** Gemini Embeddings 2 asymmetric retrieval document format. */
+export function formatSearchDocument(text: string, title?: string): string {
+  return `title: ${title?.trim() || "none"} | text: ${text}`;
+}

--- a/packages/backend/convex/processing/embeddings.ts
+++ b/packages/backend/convex/processing/embeddings.ts
@@ -5,26 +5,21 @@ import { embed, embedMany } from "ai";
 import { internal } from "../_generated/api";
 import { internalAction } from "../_generated/server";
 import { v } from "convex/values";
+import {
+  EMBEDDING_MODEL,
+  EMBEDDING_MODEL_KEY,
+  EMBEDDING_PROVIDER_OPTIONS,
+  formatSearchDocument,
+  formatSearchQuery,
+} from "./embedding_format";
 
 const google = createGoogleGenerativeAI({});
 
-export const EMBEDDING_MODEL = "gemini-embedding-2";
-export const EMBEDDING_DIMENSIONS = 1536;
-export const EMBEDDING_MODEL_KEY = "gemini-embedding-2:1536";
-
-const DOCUMENT_PROVIDER_OPTIONS = {
-  google: {
-    outputDimensionality: EMBEDDING_DIMENSIONS,
-    taskType: "RETRIEVAL_DOCUMENT",
-  },
-} as const;
-
-const QUERY_PROVIDER_OPTIONS = {
-  google: {
-    outputDimensionality: EMBEDDING_DIMENSIONS,
-    taskType: "RETRIEVAL_QUERY",
-  },
-} as const;
+export {
+  EMBEDDING_DIMENSIONS,
+  EMBEDDING_MODEL,
+  EMBEDDING_MODEL_KEY,
+} from "./embedding_format";
 
 function getEmbeddingModel() {
   return google.embeddingModel(EMBEDDING_MODEL);
@@ -38,8 +33,8 @@ export async function embedDocument(text: string): Promise<number[]> {
   const model = getEmbeddingModel();
   const result = await embed({
     model,
-    value: text,
-    providerOptions: DOCUMENT_PROVIDER_OPTIONS,
+    value: formatSearchDocument(text),
+    providerOptions: EMBEDDING_PROVIDER_OPTIONS,
   });
   return result.embedding;
 }
@@ -51,8 +46,8 @@ export async function embedQuery(text: string): Promise<number[]> {
   const model = getEmbeddingModel();
   const result = await embed({
     model,
-    value: text,
-    providerOptions: QUERY_PROVIDER_OPTIONS,
+    value: formatSearchQuery(text),
+    providerOptions: EMBEDDING_PROVIDER_OPTIONS,
   });
   return result.embedding;
 }
@@ -66,8 +61,8 @@ export async function embedGeminiDocuments(
   const model = getEmbeddingModel();
   const result = await embedMany({
     model,
-    values,
-    providerOptions: DOCUMENT_PROVIDER_OPTIONS,
+    values: values.map((value) => formatSearchDocument(value)),
+    providerOptions: EMBEDDING_PROVIDER_OPTIONS,
   });
   return { embeddings: result.embeddings };
 }

--- a/packages/backend/convex/processing/runs.ts
+++ b/packages/backend/convex/processing/runs.ts
@@ -3,9 +3,7 @@ import type { Id } from "../_generated/dataModel";
 import type { MutationCtx } from "../_generated/server";
 import { internalMutation, internalQuery } from "../_generated/server";
 import { cleanMetadataForStorage } from "../utils/metadata";
-
-// Embedding model key constant (duplicated here to avoid importing from "use node" module)
-const EMBEDDING_MODEL_KEY = "gemini-embedding-2:1536";
+import { EMBEDDING_MODEL_KEY } from "./embedding_format";
 
 /**
  * getForProcessing — minimal lookup for the workflow's get-bookmark step.

--- a/packages/backend/convex/schema.ts
+++ b/packages/backend/convex/schema.ts
@@ -54,7 +54,7 @@ export default defineSchema({
     read: v.boolean(),
     // search — single combined embedding (1536-d) is the indexed field
     searchEmbedding: v.optional(v.array(v.float64())),
-    embeddingModel: v.optional(v.string()), // e.g. "gemini-embedding-001:1536"
+    embeddingModel: v.optional(v.string()), // e.g. "gemini-embedding-2:1536:search-result-v1"
     // processing progress (drives reactive UI; replaces Inngest realtime)
     processingStep: v.optional(v.number()),
     processingError: v.optional(v.string()),

--- a/packages/backend/convex/search/actions.ts
+++ b/packages/backend/convex/search/actions.ts
@@ -16,6 +16,12 @@ import { internalAction } from "../_generated/server";
 import { authAction } from "../functions";
 import { bookmarkType } from "../schema";
 import {
+  EMBEDDING_MODEL,
+  EMBEDDING_MODEL_KEY,
+  EMBEDDING_PROVIDER_OPTIONS,
+  formatSearchQuery,
+} from "../processing/embedding_format";
+import {
   applyOpenFrequencyBoost,
   bookmarkToSearchResult,
   extractDomain,
@@ -31,7 +37,6 @@ import {
 // Constants
 // ---------------------------------------------------------------------------
 
-const EMBEDDING_MODEL_KEY = "gemini-embedding-2:1536";
 const VECTOR_SEARCH_DEFAULT_CANDIDATE_LIMIT = 50;
 const VECTOR_SEARCH_FILTERED_CANDIDATE_LIMIT = 256;
 
@@ -46,14 +51,9 @@ async function embedQueryLocal(text: string): Promise<number[]> {
   const google = createGoogleGenerativeAI({});
 
   const result = await embed({
-    model: google.embeddingModel("gemini-embedding-2"),
-    value: text,
-    providerOptions: {
-      google: {
-        outputDimensionality: 1536,
-        taskType: "RETRIEVAL_QUERY",
-      },
-    },
+    model: google.embeddingModel(EMBEDDING_MODEL),
+    value: formatSearchQuery(text),
+    providerOptions: EMBEDDING_PROVIDER_OPTIONS,
   });
 
   return result.embedding;

--- a/packages/backend/scripts/admin/README.md
+++ b/packages/backend/scripts/admin/README.md
@@ -27,3 +27,10 @@ pnpm exec tsx scripts/admin/reembed-search.ts --start --batch-size 20
 The repair only embeds bookmarks with a missing vector, an invalid vector
 dimension, or a stale `embeddingModel`. It reuses existing `vectorSummary`,
 falling back to `summary`, then `title`.
+
+The active key is format-versioned (currently
+`gemini-embedding-2:1536:search-result-v1`). Changing the query/document prompt
+contract changes this key, so a dry-run should report vectors written with an
+older prompt format as `staleModel`. Re-embed the full reported backlog before
+relying on semantic search; query vectors and stored document vectors must use
+the same format version.


### PR DESCRIPTION
## Summary
- replace unsupported Gemini Embeddings 2 taskType options with Google-recommended retrieval prompt prefixes
- apply matched formatting to both stored documents and search queries
- version the embedding contract so stale vectors are selected for controlled re-embedding
- document the dry-run-first production re-embedding workflow

## Verification
- backend embedding format tests: 3 passed
- web Gemini model and migration tests: 8 passed
- backend Convex TypeScript check: passed
- web typecheck: passed
- web lint: passed with existing warnings
- Prettier and git diff checks: passed

## Deployment note
Do not merge without scheduling the documented matched re-embedding pass. This PR does not mutate production data.