### PR TITLE
fix: use canonical subscription entitlements

### DIFF
--- a/packages/backend/convex/_generated/api.d.ts
+++ b/packages/backend/convex/_generated/api.d.ts
@@ -64,6 +64,7 @@ import type * as migration_reembed from "../migration/reembed.js";
 import type * as migration_reembed_helpers from "../migration/reembed_helpers.js";
 import type * as migration_repair_subscriptions from "../migration/repair_subscriptions.js";
 import type * as processing_detect from "../processing/detect.js";
+import type * as processing_embedding_format from "../processing/embedding_format.js";
 import type * as processing_embeddings from "../processing/embeddings.js";
 import type * as processing_gemini from "../processing/gemini.js";
 import type * as processing_handlers from "../processing/handlers.js";
@@ -168,6 +169,7 @@ declare const fullApi: ApiFromModules<{
   "migration/reembed_helpers": typeof migration_reembed_helpers;
   "migration/repair_subscriptions": typeof migration_repair_subscriptions;
   "processing/detect": typeof processing_detect;
+  "processing/embedding_format": typeof processing_embedding_format;
   "processing/embeddings": typeof processing_embeddings;
   "processing/gemini": typeof processing_gemini;
   "processing/handlers": typeof processing_handlers;

--- a/packages/backend/convex/admin/queries.ts
+++ b/packages/backend/convex/admin/queries.ts
@@ -19,6 +19,7 @@ import {
   deriveEffectivePlan,
   getLimits,
   parseCustomLimits,
+  pickCanonicalSubscription,
   type SubscriptionPlanState,
 } from "../billing/plans";
 
@@ -162,38 +163,9 @@ const trendPercent = (current: number, previous: number) =>
 /**
  * A user can own several subscription rows: cancelling and re-subscribing
  * inserts a new one rather than mutating the old, so `.first()` on the
- * `by_user` index returns the *oldest* — usually a dead row. Reading one row
- * and handing it to `deriveEffectivePlan` would then report an actively paying
- * customer as "free", and `listUsers` (which scans every row) would disagree
- * with the detail page for exactly the accounts an admin is most likely to open.
- *
- * Pick the row that actually grants entitlement: a Pro-deriving row wins, and
- * newest wins among equals.
+ * `by_user` index returns the *oldest* — usually a dead row.
  */
 const SUBSCRIPTION_PER_USER_LIMIT = 20;
-
-function pickCanonicalSubscription<
-  T extends SubscriptionPlanState & { createdAt: number },
->(subscriptions: T[]): T | null {
-  let best: T | null = null;
-  let bestIsPro = false;
-
-  for (const subscription of subscriptions) {
-    const isPro = deriveEffectivePlan(subscription) === "pro";
-    if (best === null) {
-      best = subscription;
-      bestIsPro = isPro;
-      continue;
-    }
-    // Entitlement first, recency second.
-    if (isPro !== bestIsPro ? isPro : subscription.createdAt > best.createdAt) {
-      best = subscription;
-      bestIsPro = isPro;
-    }
-  }
-
-  return best;
-}
 
 /**
  * Newest-first on purpose. Convex's default order is oldest-first, so once the

--- a/packages/backend/convex/apiKeys/helpers.ts
+++ b/packages/backend/convex/apiKeys/helpers.ts
@@ -1,6 +1,11 @@
 import { v } from "convex/values";
 import { internalQuery } from "../_generated/server";
-import { deriveEffectivePlan } from "../billing/plans";
+import {
+  deriveEffectivePlan,
+  pickCanonicalSubscription,
+} from "../billing/plans";
+
+const SUBSCRIPTION_PER_USER_LIMIT = 20;
 
 /**
  * getActiveSubscriptionForUser — internalQuery
@@ -12,14 +17,16 @@ import { deriveEffectivePlan } from "../billing/plans";
 export const getActiveSubscriptionForUser = internalQuery({
   args: { userId: v.string() },
   handler: async (ctx, args) => {
-    const sub = await ctx.db
+    const subscriptions = await ctx.db
       .query("subscriptions")
       .withIndex("by_user", (q) => q.eq("userId", args.userId))
-      .first();
-    const plan = deriveEffectivePlan(sub);
+      .order("desc")
+      .take(SUBSCRIPTION_PER_USER_LIMIT);
+    const subscription = pickCanonicalSubscription(subscriptions);
+    const plan = deriveEffectivePlan(subscription);
     if (plan !== "pro") {
       return null;
     }
-    return { plan, status: sub?.status ?? null };
+    return { plan, status: subscription?.status ?? null };
   },
 });

--- a/packages/backend/convex/billing/limits.ts
+++ b/packages/backend/convex/billing/limits.ts
@@ -12,7 +12,14 @@ import { components } from "../_generated/api";
 import type { MutationCtx } from "../_generated/server";
 import { internalMutation } from "../functions";
 import { throwLimitReached } from "../utils/errors";
-import { deriveEffectivePlan, getLimits, PLANS } from "./plans";
+import {
+  deriveEffectivePlan,
+  getLimits,
+  pickCanonicalSubscription,
+  PLANS,
+} from "./plans";
+
+const SUBSCRIPTION_PER_USER_LIMIT = 20;
 
 /**
  * startOfMonth — UTC start-of-month in milliseconds.
@@ -40,13 +47,14 @@ export async function assertCanCreateBookmark(
   const metadata = (user as { metadata?: unknown } | null)?.metadata;
 
   // 2. Get active subscription for this user.
-  const subscription = await ctx.db
+  const subscriptions = await ctx.db
     .query("subscriptions")
     .withIndex("by_user", (q) => q.eq("userId", userId))
-    .first();
+    .order("desc")
+    .take(SUBSCRIPTION_PER_USER_LIMIT);
 
   // 3. Derive plan.
-  const plan = deriveEffectivePlan(subscription);
+  const plan = deriveEffectivePlan(pickCanonicalSubscription(subscriptions));
 
   // 4. Compute effective limits (custom overrides plan defaults).
   const limits = getLimits(plan as "free" | "pro", metadata);
@@ -95,12 +103,13 @@ export async function assertCanRunProcessing(
   });
   const metadata = (user as { metadata?: unknown } | null)?.metadata;
 
-  const subscription = await ctx.db
+  const subscriptions = await ctx.db
     .query("subscriptions")
     .withIndex("by_user", (q) => q.eq("userId", userId))
-    .first();
+    .order("desc")
+    .take(SUBSCRIPTION_PER_USER_LIMIT);
 
-  const plan = deriveEffectivePlan(subscription);
+  const plan = deriveEffectivePlan(pickCanonicalSubscription(subscriptions));
 
   const limits = getLimits(plan as "free" | "pro", metadata);
 
@@ -160,13 +169,14 @@ export async function shouldSendLimitEmail(
     | undefined;
 
   // 2. Check subscription status.
-  const subscription = await ctx.db
+  const subscriptions = await ctx.db
     .query("subscriptions")
     .withIndex("by_user", (q) => q.eq("userId", userId))
-    .first();
+    .order("desc")
+    .take(SUBSCRIPTION_PER_USER_LIMIT);
 
   // Only applies to free plan users.
-  if (deriveEffectivePlan(subscription) === "pro") {
+  if (deriveEffectivePlan(pickCanonicalSubscription(subscriptions)) === "pro") {
     return false;
   }
 

--- a/packages/backend/convex/billing/plans.test.ts
+++ b/packages/backend/convex/billing/plans.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { deriveEffectivePlan, getLimits } from "./plans";
+import {
+  deriveEffectivePlan,
+  getLimits,
+  pickCanonicalSubscription,
+} from "./plans";
 
 describe("deriveEffectivePlan", () => {
   it("defaults missing subscriptions to free", () => {
@@ -66,5 +70,89 @@ describe("getLimits", () => {
       canExport: 1,
       apiAccess: 0,
     });
+  });
+});
+
+describe("pickCanonicalSubscription", () => {
+  it("uses the newest subscription row instead of an older active row", () => {
+    const olderActive = {
+      plan: "pro",
+      provider: "stripe" as const,
+      status: "active",
+      createdAt: 100,
+      updatedAt: 100,
+    };
+    const newerCanceled = {
+      plan: "free",
+      provider: "stripe" as const,
+      status: "canceled",
+      createdAt: 200,
+      updatedAt: 300,
+    };
+
+    expect(pickCanonicalSubscription([olderActive, newerCanceled])).toBe(
+      newerCanceled,
+    );
+    expect(
+      deriveEffectivePlan(pickCanonicalSubscription([olderActive, newerCanceled])),
+    ).toBe("free");
+  });
+
+  it("requires newest-first bounded scans so more than 20 historical rows cannot hide the latest downgrade", () => {
+    const olderActiveRows = Array.from({ length: 20 }, (_, index) => ({
+      plan: "pro",
+      provider: "stripe" as const,
+      status: "active",
+      createdAt: index + 1,
+      updatedAt: index + 1,
+    }));
+    const newestCanceled = {
+      plan: "free",
+      provider: "stripe" as const,
+      status: "canceled",
+      createdAt: 21,
+      updatedAt: 21,
+    };
+    const oldestFirstByUserRows = [...olderActiveRows, newestCanceled];
+
+    const defaultOldestFirstBoundedScan = oldestFirstByUserRows.slice(0, 20);
+    expect(
+      deriveEffectivePlan(
+        pickCanonicalSubscription(defaultOldestFirstBoundedScan),
+      ),
+    ).toBe("pro");
+
+    const newestFirstBoundedScan = [...oldestFirstByUserRows]
+      .sort((left, right) => right.createdAt - left.createdAt)
+      .slice(0, 20);
+
+    expect(pickCanonicalSubscription(newestFirstBoundedScan)).toBe(
+      newestCanceled,
+    );
+    expect(
+      deriveEffectivePlan(pickCanonicalSubscription(newestFirstBoundedScan)),
+    ).toBe("free");
+  });
+
+  it("keeps manual lifetime access canonical even when billing rows are newer", () => {
+    const lifetime = {
+      plan: "pro",
+      provider: "manual" as const,
+      status: "lifetime",
+      createdAt: 100,
+      updatedAt: 100,
+    };
+    const newerCanceled = {
+      plan: "free",
+      provider: "stripe" as const,
+      status: "canceled",
+      createdAt: 200,
+      updatedAt: 300,
+    };
+
+    expect(pickCanonicalSubscription([newerCanceled, lifetime])).toBe(lifetime);
+    expect(deriveEffectivePlan(pickCanonicalSubscription([newerCanceled, lifetime]))).toBe(
+      "pro",
+    );
   });
 });

--- a/packages/backend/convex/billing/plans.ts
+++ b/packages/backend/convex/billing/plans.ts
@@ -39,6 +39,9 @@ export type SubscriptionPlanState = {
   plan?: string | null;
   provider?: "stripe" | "appstore" | "manual" | null;
   status?: string | null;
+  createdAt?: number | null;
+  updatedAt?: number | null;
+  _creationTime?: number | null;
 };
 // Plain numeric shape (NOT the `as const` literal union) so merged/custom
 // limits and runtime-computed values assign cleanly.
@@ -71,6 +74,37 @@ export function isLifetimeSubscription(
     subscription.provider === "manual" &&
     subscription.status === "lifetime"
   );
+}
+
+/**
+ * Pick the single subscription row that should drive entitlements.
+ *
+ * Migration and provider-transition windows can leave more than one row per
+ * user. Never use the first row from the by_user index for authorization: it is
+ * usually the oldest row and can incorrectly preserve an old active Pro grant.
+ * Manual lifetime grants are intentionally durable; otherwise the most recently
+ * updated/created row is canonical.
+ */
+export function pickCanonicalSubscription<
+  T extends SubscriptionPlanState | null | undefined,
+>(subscriptions: readonly T[]): T | null {
+  const rows = subscriptions.filter(
+    (subscription): subscription is NonNullable<T> => Boolean(subscription),
+  );
+  if (rows.length === 0) return null;
+
+  const lifetime = rows.find((subscription) =>
+    isLifetimeSubscription(subscription),
+  );
+  if (lifetime) return lifetime;
+
+  return rows.reduce((newest, candidate) => {
+    const newestTimestamp =
+      newest.updatedAt ?? newest.createdAt ?? newest._creationTime ?? 0;
+    const candidateTimestamp =
+      candidate.updatedAt ?? candidate.createdAt ?? candidate._creationTime ?? 0;
+    return candidateTimestamp > newestTimestamp ? candidate : newest;
+  });
 }
 
 /**

--- a/packages/backend/convex/bookmarks/mutations.ts
+++ b/packages/backend/convex/bookmarks/mutations.ts
@@ -19,7 +19,11 @@ import {
   assertCanRunProcessing,
   shouldSendLimitEmail,
 } from "../billing/limits";
-import { deriveEffectivePlan, getLimits } from "../billing/plans";
+import {
+  deriveEffectivePlan,
+  getLimits,
+  pickCanonicalSubscription,
+} from "../billing/plans";
 import {
   buildBookmarkDetailDTO,
   type BookmarkDetailDTO,
@@ -43,6 +47,7 @@ const READABLE_BOOKMARK_TYPES = ["ARTICLE", "YOUTUBE"] as const;
 const MAX_BOOKMARK_NOTE_LENGTH = 2000;
 const MAX_BOOKMARK_TITLE_LENGTH = 500;
 const MAX_BOOKMARK_SUMMARY_LENGTH = 5000;
+const SUBSCRIPTION_PER_USER_LIMIT = 20;
 
 function assertValidBookmarkNote(note: string | null | undefined): void {
   if (typeof note === "string" && note.length > MAX_BOOKMARK_NOTE_LENGTH) {
@@ -574,12 +579,13 @@ export const exportCsv = authMutation({
     const userId = ctx.user.id;
 
     // Check export permission.
-    const subscription = await ctx.db
+    const subscriptions = await ctx.db
       .query("subscriptions")
       .withIndex("by_user", (q: any) => q.eq("userId", userId))
-      .first();
+      .order("desc")
+      .take(SUBSCRIPTION_PER_USER_LIMIT);
 
-    const plan = deriveEffectivePlan(subscription);
+    const plan = deriveEffectivePlan(pickCanonicalSubscription(subscriptions));
     const dbUser = await ctx.runQuery(components.betterAuth.data.getUserById, {
       userId,
     });

--- a/packages/backend/convex/chat/mutations.ts
+++ b/packages/backend/convex/chat/mutations.ts
@@ -3,10 +3,15 @@ import { v } from "convex/values";
 import { components, internal } from "../_generated/api";
 import { internalMutation } from "../_generated/server";
 import { authMutation } from "../functions";
-import { deriveEffectivePlan } from "../billing/plans";
+import {
+  deriveEffectivePlan,
+  pickCanonicalSubscription,
+} from "../billing/plans";
 import { throwNotFound } from "../utils/errors";
 import { startOfMonth } from "./usage";
 import type { Id } from "../_generated/dataModel";
+
+const SUBSCRIPTION_PER_USER_LIMIT = 20;
 
 function getFallbackConversationTitle(firstMessage: string) {
   const normalized = firstMessage.replace(/\s+/g, " ").trim();
@@ -35,17 +40,15 @@ export const checkAndIncrementUsage = internalMutation({
       .collect();
     const used = usages.length;
 
-    // 2. Fetch active subscription for userId.
-    // No combined by_user+status index; fetch by user and check status in JS.
+    // 2. Fetch canonical subscription for userId.
+    // Never let an older active row preserve Pro access after a newer
+    // cancellation/downgrade row exists.
     const allSubs = await ctx.db
       .query("subscriptions")
       .withIndex("by_user", (q) => q.eq("userId", userId))
-      .take(10);
-    const plan = allSubs.some(
-      (subscription) => deriveEffectivePlan(subscription) === "pro",
-    )
-      ? "pro"
-      : "free";
+      .order("desc")
+      .take(SUBSCRIPTION_PER_USER_LIMIT);
+    const plan = deriveEffectivePlan(pickCanonicalSubscription(allSubs));
 
     // 3. Fetch user metadata for custom limits.
     const user = await ctx.runQuery(components.betterAuth.data.getUserById, {

--- a/packages/backend/convex/chat/queries.ts
+++ b/packages/backend/convex/chat/queries.ts
@@ -1,7 +1,10 @@
 import { v } from "convex/values";
 import { components } from "../_generated/api";
 import { internalQuery } from "../_generated/server";
-import { deriveEffectivePlan } from "../billing/plans";
+import {
+  deriveEffectivePlan,
+  pickCanonicalSubscription,
+} from "../billing/plans";
 import { authQuery } from "../functions";
 import { startOfMonth } from "./usage";
 import type { Doc } from "../_generated/dataModel";
@@ -10,6 +13,7 @@ import type { UIMessage } from "ai";
 type ChatMessageRow = Doc<"chatMessages">;
 type ChatRole = UIMessage["role"];
 type TextPart = Extract<UIMessage["parts"][number], { type: "text" }>;
+const SUBSCRIPTION_PER_USER_LIMIT = 20;
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
@@ -163,17 +167,14 @@ export const getChatUsage = authQuery({
     const userId = ctx.user.id;
     const monthStart = startOfMonth();
 
-    // Fetch active subscription.
-    // No combined by_user+status index; fetch by user and check status in JS.
+    // Fetch canonical subscription. Never let an older active row preserve Pro
+    // access after a newer cancellation/downgrade row exists.
     const allSubs = await ctx.db
       .query("subscriptions")
       .withIndex("by_user", (q) => q.eq("userId", userId))
-      .take(10);
-    const plan = allSubs.some(
-      (subscription) => deriveEffectivePlan(subscription) === "pro",
-    )
-      ? "pro"
-      : "free";
+      .order("desc")
+      .take(SUBSCRIPTION_PER_USER_LIMIT);
+    const plan = deriveEffectivePlan(pickCanonicalSubscription(allSubs));
 
     // Fetch user metadata for custom limits.
     const user = await ctx.runQuery(components.betterAuth.data.getUserById, {

--- a/packages/backend/convex/subscriptions/helpers.ts
+++ b/packages/backend/convex/subscriptions/helpers.ts
@@ -1,17 +1,23 @@
 import { v } from "convex/values";
 import { internalQuery } from "../_generated/server";
-import { deriveEffectivePlan } from "../billing/plans";
+import {
+  deriveEffectivePlan,
+  pickCanonicalSubscription,
+} from "../billing/plans";
+
+const SUBSCRIPTION_PER_USER_LIMIT = 20;
 
 /** Server-only entitlement check for actions that cannot access ctx.db. */
 export const getEffectivePlanForUser = internalQuery({
   args: { userId: v.string() },
   returns: v.union(v.literal("free"), v.literal("pro")),
   handler: async (ctx, { userId }) => {
-    const subscription = await ctx.db
+    const subscriptions = await ctx.db
       .query("subscriptions")
       .withIndex("by_user", (q) => q.eq("userId", userId))
-      .first();
+      .order("desc")
+      .take(SUBSCRIPTION_PER_USER_LIMIT);
 
-    return deriveEffectivePlan(subscription);
+    return deriveEffectivePlan(pickCanonicalSubscription(subscriptions));
   },
 });

--- a/packages/backend/convex/subscriptions/queries.ts
+++ b/packages/backend/convex/subscriptions/queries.ts
@@ -8,9 +8,12 @@ import { authQuery } from "../functions";
 import {
   deriveEffectivePlan,
   getLimits,
+  pickCanonicalSubscription,
   parseCustomLimits,
 } from "../billing/plans";
 import type { Id } from "../_generated/dataModel";
+
+const SUBSCRIPTION_PER_USER_LIMIT = 20;
 
 /**
  * SubscriptionDTO shape.
@@ -67,10 +70,12 @@ export const getMine = authQuery({
   handler: async (ctx): Promise<SubscriptionDTO | null> => {
     const { user } = ctx;
 
-    const sub = await ctx.db
+    const subscriptions = await ctx.db
       .query("subscriptions")
       .withIndex("by_user", (q) => q.eq("userId", user.id))
-      .first();
+      .order("desc")
+      .take(SUBSCRIPTION_PER_USER_LIMIT);
+    const sub = pickCanonicalSubscription(subscriptions);
 
     if (!sub) return null;
 
@@ -101,10 +106,12 @@ export const getUserPlan = authQuery({
     const { user } = ctx;
 
     // 1. Fetch subscription (may be null → free).
-    const sub = await ctx.db
+    const subscriptions = await ctx.db
       .query("subscriptions")
       .withIndex("by_user", (q) => q.eq("userId", user.id))
-      .first();
+      .order("desc")
+      .take(SUBSCRIPTION_PER_USER_LIMIT);
+    const sub = pickCanonicalSubscription(subscriptions);
 
     // 2. Derive plan from subscription status.
     const plan = deriveEffectivePlan(sub);

--- a/packages/backend/convex/users/queries.ts
+++ b/packages/backend/convex/users/queries.ts
@@ -1,11 +1,14 @@
 import {
   deriveEffectivePlan,
   getLimits as getPlansLimits,
+  pickCanonicalSubscription,
   parseCustomLimits,
 } from "../billing/plans";
 import { components } from "../_generated/api";
 import { authQuery } from "../functions";
 import { deriveOnboardingFlowState } from "./onboarding";
+
+const SUBSCRIPTION_PER_USER_LIMIT = 20;
 
 /**
  * getLimits — authQuery
@@ -22,10 +25,12 @@ export const getLimits = authQuery({
     const userId = ctx.user.id;
 
     // Fetch active subscription
-    const sub = await ctx.db
+    const subscriptions = await ctx.db
       .query("subscriptions")
       .withIndex("by_user", (q) => q.eq("userId", userId))
-      .first();
+      .order("desc")
+      .take(SUBSCRIPTION_PER_USER_LIMIT);
+    const sub = pickCanonicalSubscription(subscriptions);
 
     const plan = deriveEffectivePlan(sub);
 
@@ -69,10 +74,12 @@ export const getLimits = authQuery({
 export const getOnboardingFlowState = authQuery({
   args: {},
   handler: async (ctx) => {
-    const subscription = await ctx.db
+    const subscriptions = await ctx.db
       .query("subscriptions")
       .withIndex("by_user", (q) => q.eq("userId", ctx.user.id))
-      .first();
+      .order("desc")
+      .take(SUBSCRIPTION_PER_USER_LIMIT);
+    const subscription = pickCanonicalSubscription(subscriptions);
 
     return deriveOnboardingFlowState({
       onboarding: ctx.user.onboarding,


### PR DESCRIPTION
## Summary
- Centralize canonical subscription selection for entitlement checks.
- Prevent older active/pro subscription rows from continuing to grant paid capabilities after newer canceled/free rows exist.
- Apply newest-first bounded subscription scans across API-key fallback, limits, exports, chat, subscriptions, user limits, and admin visibility.
- Add regression coverage for stale rows and >20-row subscription history.

## Test Plan
- `git diff --cached --check`
- Added-line static scan for secrets/dangerous calls: clean
- `ulimit -v unlimited; pnpm --filter @workspace/backend test convex/billing/plans.test.ts --run` (13 tests passed)
- Custom scan: `missing_order_count 0` for bounded subscription scans
- Independent reviewer: REQUEST_CHANGES on first pass, PASS after ordering fix

## Risk / Rollback
- Medium-risk entitlement hardening. Users whose paid access only came from stale subscription rows may correctly lose paid capabilities.
- Lifetime/manual grants are preserved intentionally.
- Rollback by reverting the commit, but that would restore stale entitlement grants.

## Known baseline failures
- `pnpm --filter @workspace/backend exec tsc --noEmit` is not a valid focused typecheck in this repo; it emits unrelated workspace UI JSX config errors.
- `pnpm --filter @workspace/backend exec convex codegen` requires `CONVEX_DEPLOYMENT` and was not run against production config.
